### PR TITLE
Update streak logic for daily logs

### DIFF
--- a/lib/streak.js
+++ b/lib/streak.js
@@ -1,0 +1,56 @@
+import { supabase } from '../supabaseClient';
+
+export async function updateDailyStreak(userId) {
+  if (!userId) return null;
+  const today = new Date().toISOString().split('T')[0];
+
+  // fetch latest log for this user
+  const { data: latest, error } = await supabase
+    .from('calorie_logs')
+    .select('log_date, streak_days')
+    .eq('user_id', userId)
+    .order('log_date', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('updateDailyStreak fetch error:', error.message);
+    return null;
+  }
+
+  if (latest && latest.log_date === today) {
+    // streak already updated today
+    return latest.streak_days || 0;
+  }
+
+  let newStreak = 1;
+  if (latest) {
+    const diff = new Date(today) - new Date(latest.log_date);
+    if (diff <= 86400000) {
+      newStreak = (latest.streak_days || 0) + 1;
+    }
+  }
+
+  // ensure today row exists
+  const { data: todayRow } = await supabase
+    .from('calorie_logs')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('log_date', today)
+    .maybeSingle();
+
+  if (todayRow) {
+    await supabase
+      .from('calorie_logs')
+      .update({ streak_days: newStreak })
+      .eq('id', todayRow.id);
+  } else {
+    await supabase.from('calorie_logs').insert({
+      user_id: userId,
+      log_date: today,
+      streak_days: newStreak,
+    });
+  }
+
+  return newStreak;
+}


### PR DESCRIPTION
## Summary
- add helper to update today's streak in Supabase
- log streak when calories or workouts are saved
- track current streak in StrengthTraining and CalorieTracker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fbab9b1e0832dbdf97d05a4a39595