### PR TITLE
Fix hook order in ProfileScreen

### DIFF
--- a/ProfileScreen.js
+++ b/ProfileScreen.js
@@ -288,6 +288,18 @@ export default function ProfileScreen({
 
   const weeks = useMemo(() => generateCalendar(calendarYear, calendarMonth), [calendarYear, calendarMonth]);
 
+  // XP progress bar
+  const xpNeeded = 1000;
+  const progressPct = Math.min(100, Math.floor((profile.exp / xpNeeded) * 100));
+
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: progressPct,
+      duration: 800,
+      useNativeDriver: false,
+    }).start();
+  }, [progressPct]);
+
 /** ---------------------- Early exits + loading spinners ---------------------- */
   if (!session?.user) {
     return (
@@ -323,18 +335,6 @@ export default function ProfileScreen({
     profile.first_name?.trim() ||
     session.user.user_metadata?.first_name ||
     session.user.email.split('@')[0];
-
-  // XP progress bar
-  const xpNeeded = 1000;
-  const progressPct = Math.min(100, Math.floor((profile.exp / xpNeeded) * 100));
-
-  useEffect(() => {
-    Animated.timing(progressAnim, {
-      toValue: progressPct,
-      duration: 800,
-      useNativeDriver: false,
-    }).start();
-  }, [progressPct]);
 
 
   /** ---------------------- Main Render ---------------------- */


### PR DESCRIPTION
## Summary
- maintain consistent hook order in `ProfileScreen`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fc55b5420832db8731a590333c1a8