### PR TITLE
Add rank and challenge tabs

### DIFF
--- a/App.js
+++ b/App.js
@@ -31,6 +31,8 @@ import BodyFatCalculator from './body-fat';
 import CalorieTracker from './CalorieTracker';
 import Leaderboard from './leaderboard';
 import RealTimeVideo from './RealTimeVideo';
+import RankScreen from './RankScreen';
+import ChallengesScreen from './ChallengesScreen';
 
 import styles from './styles';      // your existing global styles
 import popUpStyles from './popUpStyles';  // new banner styles
@@ -293,11 +295,13 @@ function MainApp({ session, setSession, showWelcome, setShowWelcome, welcomeAnim
   const deleteVideo = (v) => setVideos((prev) => prev.filter((x) => x.id !== v.id));
 
   const tabs = [
+    { icon: 'podium', screen: 'rank', label: 'Rank' },
     { icon: 'calculator', screen: 'calories', label: 'Calories' },
     { icon: 'body', screen: 'body', label: 'Body' },
     { icon: 'add', screen: 'home', main: true },
     { icon: 'barbell', screen: 'strength', label: 'Strength' },
     { icon: 'trophy', screen: 'leaderboard', label: 'Top' },
+    { icon: 'list', screen: 'challenges', label: 'Goals' },
   ];
 
   const Navbar = () => (
@@ -666,6 +670,24 @@ function MainApp({ session, setSession, showWelcome, setShowWelcome, welcomeAnim
 
     case 'leaderboard':
       return <LeaderboardScreen />;
+
+    case 'rank':
+      return (
+        <View style={[styles.container, !isDarkMode && styles.containerLight]}>
+          <Header />
+          <RankScreen session={session} isDarkMode={isDarkMode} />
+          <Navbar />
+        </View>
+      );
+
+    case 'challenges':
+      return (
+        <View style={[styles.container, !isDarkMode && styles.containerLight]}>
+          <Header />
+          <ChallengesScreen isDarkMode={isDarkMode} />
+          <Navbar />
+        </View>
+      );
 
     case 'profile':
       return (

--- a/ChallengesScreen.js
+++ b/ChallengesScreen.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import styles from './styles';
+
+const challenges = [
+  { title: 'Complete 5 Workouts this Week', progress: 3, total: 5 },
+  { title: 'Upload 3 Form Videos', progress: 1, total: 3 },
+  { title: 'Earn 1500 XP', progress: 800, total: 1500 },
+];
+
+export default function ChallengesScreen({ isDarkMode = true }) {
+  return (
+    <ScrollView style={[styles.container, !isDarkMode && styles.containerLight]}>
+      <View style={{ padding: 20 }}>
+        <Text style={[styles.sectionTitle, !isDarkMode && styles.sectionTitleLight]}>Challenges</Text>
+        {challenges.map((c, idx) => {
+          const pct = Math.min(100, Math.round((c.progress / c.total) * 100));
+          return (
+            <View
+              key={idx}
+              style={[styles.levelCard, !isDarkMode && styles.levelCardLight, { marginBottom: 20 }]}
+            >
+              <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 12 }}>
+                <Ionicons name="checkmark-circle" size={24} color="#1abc9c" style={{ marginRight: 12 }} />
+                <Text style={[styles.statLabel, !isDarkMode && styles.statLabelLight]}>{c.title}</Text>
+              </View>
+              <View style={[styles.progressBar, !isDarkMode && styles.progressBarLight]}>
+                <View style={[styles.progressFill, { width: `${pct}%` }]} />
+              </View>
+              <Text style={[styles.progressText, !isDarkMode && styles.progressTextLight]}>
+                {c.progress} / {c.total}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}

--- a/RankScreen.js
+++ b/RankScreen.js
@@ -1,0 +1,109 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Text, ScrollView, ActivityIndicator, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import styles from './styles';
+import { supabase } from './supabaseClient';
+
+export default function RankScreen({ session, isDarkMode = true }) {
+  const [profile, setProfile] = useState({ level: 0, exp: 0 });
+  const [loading, setLoading] = useState(true);
+  const [userRank, setUserRank] = useState(null);
+  const [userPercentile, setUserPercentile] = useState(null);
+  const progressAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const userId = session.user.id;
+        const { data, error } = await supabase
+          .from('profile')
+          .select('level, exp')
+          .eq('user_id', userId)
+          .single();
+        if (!error && data) {
+          setProfile({ level: data.level || 0, exp: data.exp || 0 });
+          await fetchUserRank(data.exp || 0);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (session?.user) fetchData();
+  }, [session]);
+
+  async function fetchUserRank(userExp) {
+    try {
+      const { count: higherCount, error: higherError } = await supabase
+        .from('profile')
+        .select('exp', { count: 'exact', head: true })
+        .gt('exp', userExp);
+      if (higherError) throw higherError;
+      const { count: totalCount, error: totalError } = await supabase
+        .from('profile')
+        .select('exp', { count: 'exact', head: true });
+      if (totalError) throw totalError;
+      const rank = (higherCount || 0) + 1;
+      setUserRank(rank);
+      const percentile = totalCount
+        ? (((totalCount - rank) / totalCount) * 100).toFixed(1)
+        : 0;
+      setUserPercentile(percentile);
+    } catch (err) {
+      console.error('Error fetching rank:', err);
+    }
+  }
+
+  const xpNeeded = 1000;
+  const progressPct = Math.min(100, Math.floor((profile.exp / xpNeeded) * 100));
+
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: progressPct,
+      duration: 800,
+      useNativeDriver: false,
+    }).start();
+  }, [progressPct]);
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color="#1abc9c" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={[styles.container, !isDarkMode && styles.containerLight]}>
+      <View style={{ padding: 20 }}>
+        <Text style={[styles.sectionTitle, !isDarkMode && styles.sectionTitleLight]}>Your Rank</Text>
+        <View style={[styles.levelCard, !isDarkMode && styles.levelCardLight]}>
+          <View style={styles.levelInfo}>
+            <Text style={styles.levelNumber}>{profile.level}</Text>
+            <Text style={styles.rankText}>
+              {profile.level < 5 ? 'Rookie' : profile.level < 10 ? 'Intermediate' : 'Pro'}
+            </Text>
+          </View>
+          <View style={[styles.progressBar, !isDarkMode && styles.progressBarLight]}>
+            <Animated.View
+              style={[
+                styles.progressFill,
+                {
+                  width: progressAnim.interpolate({
+                    inputRange: [0, 100],
+                    outputRange: ['0%', '100%'],
+                  }),
+                },
+              ]}
+            />
+          </View>
+          <Text style={[styles.progressText, !isDarkMode && styles.progressTextLight]}>
+            {profile.exp} / {xpNeeded} XP
+          </Text>
+          {userRank && (
+            <Text style={[styles.rankInfo, !isDarkMode && styles.rankInfoLight]}>Rank #{userRank} • Top {userPercentile}%</Text>
+          )}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
## Summary
- add Rank screen for player level tracking
- add Challenges screen with simple goal cards
- integrate new tabs into navbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fd519e9dc832dbb31e8420f21eb01