### PR TITLE
Add rotating challenges with streak and XP rewards

### DIFF
--- a/App.js
+++ b/App.js
@@ -40,6 +40,7 @@ import TopBar from './components/TopBar';
 import { supabase } from './supabaseClient';
 
 const LIVE_WORKOUT_ENABLED = true;
+const PREMIUM_USER = true;
 
 export default function App() {
   const [session, setSession] = useState(null);
@@ -684,7 +685,7 @@ function MainApp({ session, setSession, showWelcome, setShowWelcome, welcomeAnim
       return (
         <View style={[styles.container, !isDarkMode && styles.containerLight]}>
           <Header />
-          <ChallengesScreen isDarkMode={isDarkMode} />
+          <ChallengesScreen session={session} isDarkMode={isDarkMode} isPremium={PREMIUM_USER} onStreakUpdate={(s)=>setStreak(s)} />
           <Navbar />
         </View>
       );

--- a/ChallengesScreen.js
+++ b/ChallengesScreen.js
@@ -1,39 +1,107 @@
-import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import styles from './styles';
+import { updateDailyStreak } from './lib/streak';
+import { addExp } from './lib/profile';
+import { supabase } from './supabaseClient';
 
-const challenges = [
-  { title: 'Complete 5 Workouts this Week', progress: 3, total: 5 },
-  { title: 'Upload 3 Form Videos', progress: 1, total: 3 },
-  { title: 'Earn 1500 XP', progress: 800, total: 1500 },
+const dailySets = [
+  [
+    { id: 'w1', title: 'Complete a Workout', total: 1 },
+    { id: 'v1', title: 'Upload a Form Video', total: 1 },
+    { id: 'xp1', title: 'Earn 500 XP', total: 1 },
+  ],
+  [
+    { id: 'r1', title: 'Run 2 Miles', total: 1 },
+    { id: 's1', title: 'Do 10 Minutes Stretching', total: 1 },
+    { id: 'f1', title: 'Log Your Meals', total: 1 },
+  ],
 ];
 
-export default function ChallengesScreen({ isDarkMode = true }) {
+const premiumSet = [
+  { id: 'p1', title: 'Try a Live Workout', total: 1 },
+  { id: 'p2', title: 'Share a PR Video', total: 1 },
+  { id: 'p3', title: 'Request Form Feedback', total: 1 },
+];
+
+export default function ChallengesScreen({ session, isPremium = false, onStreakUpdate, isDarkMode = true }) {
+  const [challenges, setChallenges] = useState([]);
+  const [premiumChallenges, setPremiumChallenges] = useState([]);
+  const [rewarded, setRewarded] = useState(false);
+  const [premiumRewarded, setPremiumRewarded] = useState(false);
+
+  useEffect(() => {
+    const dayOfYear = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
+    const idx = dayOfYear % dailySets.length;
+    setChallenges(dailySets[idx].map((c) => ({ ...c, progress: 0 })));
+    setPremiumChallenges(premiumSet.map((c) => ({ ...c, progress: 0 })));
+  }, []);
+
+  const handleComplete = async (id, premium = false) => {
+    const list = premium ? premiumChallenges : challenges;
+    const updated = list.map((c) => (c.id === id ? { ...c, progress: c.total } : c));
+    premium ? setPremiumChallenges(updated) : setChallenges(updated);
+
+    const userId = session?.user?.id;
+    if (userId) {
+      const newStreak = await updateDailyStreak(userId);
+      if (typeof newStreak === 'number' && onStreakUpdate) onStreakUpdate(newStreak);
+    }
+
+    const allDone = updated.every((c) => c.progress >= c.total);
+    const alreadyRewarded = premium ? premiumRewarded : rewarded;
+    if (allDone && !alreadyRewarded) {
+      premium ? setPremiumRewarded(true) : setRewarded(true);
+      if (userId) await addExp(userId, 1000);
+      Alert.alert('Great Job!', `You earned 1000 XP for completing ${premium ? 'premium ' : ''}challenges!`);
+    }
+  };
+
+  const renderChallenge = (c, premium = false) => {
+    const pct = Math.min(100, Math.round((c.progress / c.total) * 100));
+    const done = c.progress >= c.total;
+    return (
+      <View key={c.id} style={[styles.levelCard, !isDarkMode && styles.levelCardLight, { marginBottom: 20 }]}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 12 }}>
+          <Ionicons
+            name={done ? 'checkmark-circle' : 'ellipse-outline'}
+            size={24}
+            color={done ? '#1abc9c' : '#999'}
+            style={{ marginRight: 12 }}
+          />
+          <Text style={[styles.statLabel, !isDarkMode && styles.statLabelLight]}>{c.title}</Text>
+        </View>
+        <View style={[styles.progressBar, !isDarkMode && styles.progressBarLight]}>
+          <View style={[styles.progressFill, { width: `${pct}%` }]} />
+        </View>
+        <Text style={[styles.progressText, !isDarkMode && styles.progressTextLight]}>
+          {done ? 'Done' : `${c.progress} / ${c.total}`}
+        </Text>
+        {!done && (
+          <TouchableOpacity onPress={() => handleComplete(c.id, premium)} style={{ marginTop: 8 }}>
+            <Text style={{ color: '#1abc9c', textAlign: 'center' }}>Mark Complete</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  };
+
   return (
     <ScrollView style={[styles.container, !isDarkMode && styles.containerLight]}>
       <View style={{ padding: 20 }}>
-        <Text style={[styles.sectionTitle, !isDarkMode && styles.sectionTitleLight]}>Challenges</Text>
-        {challenges.map((c, idx) => {
-          const pct = Math.min(100, Math.round((c.progress / c.total) * 100));
-          return (
-            <View
-              key={idx}
-              style={[styles.levelCard, !isDarkMode && styles.levelCardLight, { marginBottom: 20 }]}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 12 }}>
-                <Ionicons name="checkmark-circle" size={24} color="#1abc9c" style={{ marginRight: 12 }} />
-                <Text style={[styles.statLabel, !isDarkMode && styles.statLabelLight]}>{c.title}</Text>
-              </View>
-              <View style={[styles.progressBar, !isDarkMode && styles.progressBarLight]}>
-                <View style={[styles.progressFill, { width: `${pct}%` }]} />
-              </View>
-              <Text style={[styles.progressText, !isDarkMode && styles.progressTextLight]}>
-                {c.progress} / {c.total}
-              </Text>
+        <Text style={[styles.sectionTitle, !isDarkMode && styles.sectionTitleLight]}>Daily Challenges</Text>
+        {challenges.map((c) => renderChallenge(c))}
+        <Text style={[styles.sectionTitle, { marginTop: 20 }, !isDarkMode && styles.sectionTitleLight]}>
+          Premium Challenges
+        </Text>
+        {isPremium
+          ? premiumChallenges.map((c) => renderChallenge(c, true))
+          : (
+            <View style={[styles.levelCard, !isDarkMode && styles.levelCardLight]}>
+              <Text style={[styles.statLabel, !isDarkMode && styles.statLabelLight]}>Premium challenges locked</Text>
             </View>
-          );
-        })}
+          )}
       </View>
     </ScrollView>
   );

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -48,3 +48,28 @@ export async function fetchMyProfile() {
   if (error) throw error;
   return data;
 }
+
+// Add experience points to the user's profile. Returns new total exp or null on failure.
+export async function addExp(userId, amount) {
+  if (!userId || !amount) return null;
+  const { data: profile, error } = await supabase
+    .from('profile')
+    .select('exp')
+    .eq('user_id', userId)
+    .single();
+  if (error) {
+    console.warn('addExp fetch error:', error.message);
+    return null;
+  }
+  const newExp = (profile?.exp || 0) + amount;
+  const { error: updateError } = await supabase
+    .from('profile')
+    .update({ exp: newExp })
+    .eq('user_id', userId);
+  if (updateError) {
+    console.warn('addExp update error:', updateError.message);
+    return null;
+  }
+  return newExp;
+}
+


### PR DESCRIPTION
## Summary
- rotate daily and premium challenges
- award XP for completing all challenges
- update streak and EXP when a challenge is completed
- pass session/premium info to challenges screen

## Testing
- `npm install`
- `npm run lint` *(fails: no script)*

------
https://chatgpt.com/codex/tasks/task_e_6840b33e9a9c832da7c7f7a9c362a673